### PR TITLE
[easy] Fixed typo in OOM message

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1446,7 +1446,7 @@ class DeviceCachingAllocator {
           format_size(alloc_size),
           ". GPU ",
           device,
-          " has a total capacty of ",
+          " has a total capacity of ",
           format_size(device_total),
           " of which ",
           format_size(device_free),


### PR DESCRIPTION
Fixes a simple typo "capacty" -> "capacity" in a user-facing OOM message.